### PR TITLE
Replace depreciated Handlebars references with UI and Spacebars

### DIFF
--- a/roles/package.js
+++ b/roles/package.js
@@ -4,9 +4,9 @@ Package.describe({
 
 Package.on_use(function (api) {
   var both = ['client', 'server'];
-  api.use(['underscore', 'handlebars', 'accounts-base'], both);
+  api.use(['underscore', 'ui', 'accounts-base'], both);
 
-  api.export && api.export('Roles'); 
+  api.export && api.export('Roles');
 
   api.add_files('roles_server.js', 'server');
   api.add_files('roles_common.js', both);

--- a/roles/roles_client.js
+++ b/roles/roles_client.js
@@ -15,10 +15,10 @@
 //
 // Use a semi-private variable rather than declaring Handlebars
 // helpers directly so that we can unit test the helpers.
-// XXX For some reason, the Handlebars helpers are not registered 
+// XXX For some reason, the Handlebars helpers are not registered
 // before the tests run.
 //
-Roles._handlebarsHelpers = {
+Roles._uiHelpers = {
 
   /**
    * Handlebars helper to check if current user is in at least one
@@ -39,7 +39,7 @@ Roles._handlebarsHelpers = {
    * @param {String} [group] Optional, name of group to check
    * @return {Boolean} true if current user is in at least one of the target roles
    * @static
-   * @for HandlebarsHelpers 
+   * @for HandlebarsHelpers
    */
   isInRole: function (role, group) {
     var user = Meteor.user(),
@@ -70,12 +70,12 @@ Roles._handlebarsHelpers = {
 }
 
 
-if ('undefined' !== typeof Handlebars) {
-  _.each(Roles._handlebarsHelpers, function (func, name) {
-    Handlebars.registerHelper(name, func)
+if (typeof UI !== "undefined") {
+  _.each(Roles._uiHelpers, function (func, name) {
+    UI.registerHelper(name, func)
   })
 } else {
-  console.log('WARNING: Roles Handlebars helpers not registered. Handlebars not defined')
+  console.log('WARNING: Roles UI not registered. UI not defined')
 }
 
 }());


### PR DESCRIPTION
Handlebars namespace depreciated in 0.8.0: https://github.com/meteor/meteor/wiki/Using-Blaze#handlebars-namespace-deprecated 

Hopefully this is a helpful start for the changes needed. Note: I haven't tested these changes extensively.
