### PR TITLE
Added a method to check inheritance of roles

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -1231,6 +1231,47 @@ _.extend(Roles, {
   },
 
   /**
+   * Find out if a role is an ancestor of another role.
+   *
+   * WARNING: If you check this on the client, please make sure all roles are published.
+   *
+   * @method isParentOf
+   * @param {String} parentRoleName The role you want to research.
+   * @param {String} childRoleName The role you expect to be among the children of parentRoleName.
+   * @static
+   */
+  isParentOf: function (parentRoleName, childRoleName) {
+    if (parentRoleName === childRoleName) {
+      return true;
+    }
+
+    if (parentRoleName == null || childRoleName == null) {
+      return false;
+    }
+
+    Roles._checkRoleName(parentRoleName);
+    Roles._checkRoleName(childRoleName);
+
+    var rolesToCheck = [parentRoleName];
+    while (rolesToCheck.length !== 0) {
+      var roleName = rolesToCheck.pop();
+
+      if (roleName === childRoleName) {
+        return true;
+      }
+
+      var role = Meteor.roles.findOne({_id: roleName});
+
+      // This should not happen, but this is a problem to address at some other time.
+      if (!role) continue;
+
+      rolesToCheck = rolesToCheck.concat(_.pluck(role.children, '_id'));
+    }
+
+    return false;
+  },
+
+  /**
    * Normalize options.
    *
    * @method _normalizeOptions

--- a/roles/tests/server.js
+++ b/roles/tests/server.js
@@ -2611,6 +2611,57 @@
       test.isFalse(Roles.userIsInRole(users.eve, undefined, {anyScope: true}));
     });
 
+Tinytest.add(
+  'roles - isParentOf - returns false for unknown roles',
+  function (test) {
+    reset();
+
+    Roles.createRole('admin');
+
+    test.isFalse(Roles.isParentOf('admin', 'unknown'));
+    test.isFalse(Roles.isParentOf('admin', null));
+    test.isFalse(Roles.isParentOf('admin', undefined));
+
+    test.isFalse(Roles.isParentOf('unknown', 'admin'));
+    test.isFalse(Roles.isParentOf(null, 'admin'));
+    test.isFalse(Roles.isParentOf(undefined, 'admin'));
+  });
+
+Tinytest.add(
+  'roles - isParentOf - returns false if role is not parent of',
+  function (test) {
+    reset();
+
+    Roles.createRole('admin');
+    Roles.createRole('editor');
+    Roles.createRole('user');
+    Roles.addRolesToParent(['editor'], 'admin');
+    Roles.addRolesToParent(['user'], 'editor');
+
+    test.isFalse(Roles.isParentOf('user', 'admin'));
+    test.isFalse(Roles.isParentOf('editor', 'admin'));
+  });
+
+Tinytest.add(
+  'roles - isParentOf - returns true if role is parent of the demanded role',
+  function (test) {
+    reset();
+
+    Roles.createRole('admin');
+    Roles.createRole('editor');
+    Roles.createRole('user');
+    Roles.addRolesToParent(['editor'], 'admin');
+    Roles.addRolesToParent(['user'], 'editor');
+
+    test.isTrue(Roles.isParentOf('admin', 'user'));
+    test.isTrue(Roles.isParentOf('editor', 'user'));
+    test.isTrue(Roles.isParentOf('admin', 'editor'));
+
+    test.isTrue(Roles.isParentOf('admin', 'admin'));
+    test.isTrue(Roles.isParentOf('editor', 'editor'));
+    test.isTrue(Roles.isParentOf('user', 'user'));
+  });
+
   function printException (ex) {
     var tmp = {};
     for (var key in ex) {


### PR DESCRIPTION
I've added a method where you can check if a role is inherited by another one, first described and discussed in https://github.com/alanning/meteor-roles/pull/234, now rebased and squashed.