### PR TITLE
Make sure id is a string before querying users collection

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -822,6 +822,7 @@ Object.assign(Roles, {
     }
 
     if (!id) return false
+    if (typeof id !== 'string') return false
 
     if (options.anyScope) {
       query = {


### PR DESCRIPTION
Potential issue if people use `ObjectId` instead of string ids. But I believe we can ignore that for meteor?

Closes #323 