### PR TITLE
Remove link to the online demo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,6 @@ The `examples` directory contains Meteor apps which show off the following featu
 * 'Sign-in required' app with up-front login page using `accounts-ui`
 * Client-side routing
 
-View the `flow-router` example app online @  <a href="http://roles.meteor.com/" target="_blank">http://roles.meteor.com/</a>
-
   1. `git clone https://github.com/Meteor-Community-Packages/meteor-roles.git`
   2. choose an example, eg.
     * `cd meteor-roles/examples/iron-router` or


### PR DESCRIPTION
This http://roles.meteor.com/ no longer works since *.meteor.com was taken down