### PR TITLE
Use createIndex

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
+# Changelog
+
 ## v3.4.0
 
-* Use the new `createIndex` instead of `_ensureIndex`
+* Use the new `createIndex` instead of `_ensureIndex` if available
 
 ## v3.3.0
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## v3.4.0
+
+* Use the new `createIndex` instead of `_ensureIndex`
+
 ## v3.3.0
 
 * Update dependencies

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 })
 
 Package.onUse(function (api) {
-  api.versionsFrom('2.3')
+  api.versionsFrom(['1.12', '2.3'])
 
   var both = ['client', 'server']
 

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 })
 
 Package.onUse(function (api) {
-  api.versionsFrom('2.4')
+  api.versionsFrom('2.3')
 
   var both = ['client', 'server']
 

--- a/package.js
+++ b/package.js
@@ -2,13 +2,13 @@
 
 Package.describe({
   summary: 'Authorization package for Meteor',
-  version: '3.3.0',
+  version: '3.4.0',
   git: 'https://github.com/Meteor-Community-Packages/meteor-roles.git',
   name: 'alanning:roles'
 })
 
 Package.onUse(function (api) {
-  api.versionsFrom(['1.12', '2.3'])
+  api.versionsFrom('2.4')
 
   var both = ['client', 'server']
 
@@ -45,7 +45,7 @@ Package.onTest(function (api) {
     'chai': '4.2.0'
   })
 
-  api.versionsFrom(['1.12', '2.3'])
+  api.versionsFrom('2.4')
 
   var both = ['client', 'server']
 

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -1,12 +1,12 @@
 /* global Meteor, Roles */
 
-Meteor.roleAssignment._ensureIndex({ 'user._id': 1, 'inheritedRoles._id': 1, scope: 1 })
-Meteor.roleAssignment._ensureIndex({ 'user._id': 1, 'role._id': 1, scope: 1 })
-Meteor.roleAssignment._ensureIndex({ 'role._id': 1 })
-Meteor.roleAssignment._ensureIndex({ scope: 1, 'user._id': 1, 'inheritedRoles._id': 1 }) // Adding userId and roleId might speed up other queries depending on the first index
-Meteor.roleAssignment._ensureIndex({ 'inheritedRoles._id': 1 })
+Meteor.roleAssignment.createIndex({ 'user._id': 1, 'inheritedRoles._id': 1, scope: 1 })
+Meteor.roleAssignment.createIndex({ 'user._id': 1, 'role._id': 1, scope: 1 })
+Meteor.roleAssignment.createIndex({ 'role._id': 1 })
+Meteor.roleAssignment.createIndex({ scope: 1, 'user._id': 1, 'inheritedRoles._id': 1 }) // Adding userId and roleId might speed up other queries depending on the first index
+Meteor.roleAssignment.createIndex({ 'inheritedRoles._id': 1 })
 
-Meteor.roles._ensureIndex({ 'children._id': 1 })
+Meteor.roles.createIndex({ 'children._id': 1 })
 
 /*
  * Publish logged-in user's roles so client-side checks can work.
@@ -356,8 +356,8 @@ Object.assign(Roles, {
   _backwardMigrate2: function (assignmentSelector) {
     assignmentSelector = assignmentSelector || {}
 
-    Meteor.users._ensureIndex({ 'roles._id': 1, 'roles.scope': 1 })
-    Meteor.users._ensureIndex({ 'roles.scope': 1 })
+    Meteor.users.createIndex({ 'roles._id': 1, 'roles.scope': 1 })
+    Meteor.users.createIndex({ 'roles.scope': 1 })
 
     Meteor.roleAssignment.find(assignmentSelector).forEach(r => {
       const roles = Meteor.users.findOne({ _id: r.user._id }).roles || []

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -1,12 +1,21 @@
 /* global Meteor, Roles */
+if (Meteor.roles.createIndex) {
+  Meteor.roleAssignment.createIndex({ 'user._id': 1, 'inheritedRoles._id': 1, scope: 1 })
+  Meteor.roleAssignment.createIndex({ 'user._id': 1, 'role._id': 1, scope: 1 })
+  Meteor.roleAssignment.createIndex({ 'role._id': 1 })
+  Meteor.roleAssignment.createIndex({ scope: 1, 'user._id': 1, 'inheritedRoles._id': 1 }) // Adding userId and roleId might speed up other queries depending on the first index
+  Meteor.roleAssignment.createIndex({ 'inheritedRoles._id': 1 })
 
-Meteor.roleAssignment.createIndex({ 'user._id': 1, 'inheritedRoles._id': 1, scope: 1 })
-Meteor.roleAssignment.createIndex({ 'user._id': 1, 'role._id': 1, scope: 1 })
-Meteor.roleAssignment.createIndex({ 'role._id': 1 })
-Meteor.roleAssignment.createIndex({ scope: 1, 'user._id': 1, 'inheritedRoles._id': 1 }) // Adding userId and roleId might speed up other queries depending on the first index
-Meteor.roleAssignment.createIndex({ 'inheritedRoles._id': 1 })
+  Meteor.roles.createIndex({ 'children._id': 1 })
+} else {
+  Meteor.roleAssignment._ensureIndex({ 'user._id': 1, 'inheritedRoles._id': 1, scope: 1 })
+  Meteor.roleAssignment._ensureIndex({ 'user._id': 1, 'role._id': 1, scope: 1 })
+  Meteor.roleAssignment._ensureIndex({ 'role._id': 1 })
+  Meteor.roleAssignment._ensureIndex({ scope: 1, 'user._id': 1, 'inheritedRoles._id': 1 }) // Adding userId and roleId might speed up other queries depending on the first index
+  Meteor.roleAssignment._ensureIndex({ 'inheritedRoles._id': 1 })
 
-Meteor.roles.createIndex({ 'children._id': 1 })
+  Meteor.roles._ensureIndex({ 'children._id': 1 })
+}
 
 /*
  * Publish logged-in user's roles so client-side checks can work.

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -365,8 +365,13 @@ Object.assign(Roles, {
   _backwardMigrate2: function (assignmentSelector) {
     assignmentSelector = assignmentSelector || {}
 
-    Meteor.users.createIndex({ 'roles._id': 1, 'roles.scope': 1 })
-    Meteor.users.createIndex({ 'roles.scope': 1 })
+    if (Meteor.users.createIndex) {
+      Meteor.users.createIndex({ 'roles._id': 1, 'roles.scope': 1 })
+      Meteor.users.createIndex({ 'roles.scope': 1 })
+    } else {
+      Meteor.users._ensureIndex({ 'roles._id': 1, 'roles.scope': 1 })
+      Meteor.users._ensureIndex({ 'roles.scope': 1 })
+    }
 
     Meteor.roleAssignment.find(assignmentSelector).forEach(r => {
       const roles = Meteor.users.findOne({ _id: r.user._id }).roles || []


### PR DESCRIPTION
Starting with Meteor 2.4 `_ensureIndex` is deprecated, so we are switching to `createIndex` to not show deprecation warnings.