### PR TITLE
Fixed typescript definitions.

### DIFF
--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -430,7 +430,9 @@ declare namespace Roles {
 
 } // module
 
-declare namespace Meteor {
-  var roles: Mongo.Collection<Roles.Role>
-  var roleAssignment: Mongo.Collection<Roles.RoleAssignment>
+declare module 'meteor/meteor' {
+  namespace Meteor {
+    const roles: Mongo.Collection<Roles.Role>
+    const roleAssignment: Mongo.Collection<Roles.RoleAssignment>
+  }
 }


### PR DESCRIPTION
Just a small change to the definitions file to fix Meteor.roles and Meteor.roleAssignment types.

Resolves #338.